### PR TITLE
Release 0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruxpay/rn-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,9 +863,9 @@
       }
     },
     "@cruxpay/js-sdk": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@cruxpay/js-sdk/-/js-sdk-0.1.5.tgz",
-      "integrity": "sha512-WemGWCVCihQjpetOMk8MvlGUUVSafo1pj7KoKFiqJEYsD7VVBaC8WQpN0tE3D65CXggB1iuylTaoHS7H7G+eFw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@cruxpay/js-sdk/-/js-sdk-0.1.8.tgz",
+      "integrity": "sha512-sEaHx/EGIVciPPZf2PbISgEsQ2DnoqsnbErT+HzqgZubvwYuBiAUfOFIKlU0d2b1RwG0AeATXZGo2t2Gy2JDrA==",
       "requires": {
         "@mojotech/json-type-validation": "^3.1.0",
         "bip39": "^3.0.2",
@@ -7291,9 +7291,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "uglify-js": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
-      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruxpay/rn-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "CruxPay React Native SDK",
   "unpkg": "dist/cruxpay-sdk-rn.js",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cruxprotocol/rn-sdk#readme",
   "dependencies": {
-    "@cruxpay/js-sdk": "0.1.5"
+    "@cruxpay/js-sdk": "0.1.8"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.4"


### PR DESCRIPTION
- Use @cruxpay/js-sdk [0.1.8](https://github.com/cruxprotocol/js-sdk/releases/tag/v0.1.8)